### PR TITLE
add 800k-only profile

### DIFF
--- a/conf/profiles-800k-only.xml
+++ b/conf/profiles-800k-only.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profiles>
+  <profile>
+	<description>800k</description>
+    <dimensions>autox480</dimensions>
+    <vbitrate>768k</vbitrate>
+    <abitrate>32k</abitrate>
+    <enabled>1</enabled>
+  </profile>
+</profiles>


### PR DESCRIPTION
Hi @rrasch ,

Could you please merge this into your code and deploy?
The 800k-only profile is really useful for generating access files for curators to see the video content without having to generate all of the high-quality files.

Please let me know if you have any questions or need more info.
Thank you for your time!
Joe
