### PR TITLE
add mobile-only profiles

### DIFF
--- a/conf/profiles-movie-scenes-mobile.xml
+++ b/conf/profiles-movie-scenes-mobile.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profiles>
+   <profile>
+      <description>Mobile Low Movie Scenes</description>
+      <dimensions>autox234</dimensions>
+      <vbitrate>800k</vbitrate>
+      <abitrate>128k</abitrate>
+      <device>mobile</device>
+      <enabled>1</enabled>
+   </profile>
+   <profile>
+      <description>Mobile Medium Movie Scenes</description>
+      <dimensions>autox352</dimensions>
+      <vbitrate>2400k</vbitrate>
+      <abitrate>128k</abitrate>
+      <device>mobile</device>
+      <enabled>1</enabled>
+   </profile>
+   <profile>
+      <description>Mobile High Movie Scenes</description>
+      <dimensions>autox544</dimensions>
+      <vbitrate>4000k</vbitrate>
+      <abitrate>128k</abitrate>
+      <device>mobile</device>
+      <enabled>1</enabled>
+   </profile>
+   <profile>
+      <description>Mobile 720p Movie Scenes</description>
+      <dimensions>autox576</dimensions>
+      <vbitrate>8000k</vbitrate>
+      <abitrate>128k</abitrate>
+      <device>mobile</device>
+      <enabled>1</enabled>
+   </profile>
+   <profile>
+      <description>Mobile 1080p Movie Scenes</description>
+      <dimensions>autox576</dimensions>
+      <vbitrate>12000k</vbitrate>
+      <abitrate>128k</abitrate>
+      <device>mobile</device>
+      <enabled>1</enabled>
+   </profile>
+</profiles>

--- a/conf/profiles-talking-heads-mobile.xml
+++ b/conf/profiles-talking-heads-mobile.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profiles>
+   <profile>
+      <description>Mobile Low Talking Heads</description>
+      <dimensions>autox234</dimensions>
+      <vbitrate>800k</vbitrate>
+      <abitrate>128k</abitrate>
+      <device>mobile</device>
+      <enabled>1</enabled>
+   </profile>
+   <profile>
+      <description>Mobile Medium Talking Heads</description>
+      <dimensions>autox352</dimensions>
+      <vbitrate>800k</vbitrate>
+      <abitrate>128k</abitrate>
+      <device>mobile</device>
+      <enabled>1</enabled>
+   </profile>
+   <profile>
+      <description>Mobile High Talking Heads</description>
+      <dimensions>autox544</dimensions>
+      <vbitrate>2400k</vbitrate>
+      <abitrate>128k</abitrate>
+      <device>mobile</device>
+      <enabled>1</enabled>
+   </profile>
+   <profile>
+      <description>Mobile 720p Talking Heads</description>
+      <dimensions>autox576</dimensions>
+      <vbitrate>6000k</vbitrate>
+      <abitrate>128k</abitrate>
+      <device>mobile</device>
+      <enabled>1</enabled>
+   </profile>
+   <profile>
+      <description>Mobile 1080p Talking Heads</description>
+      <dimensions>autox576</dimensions>
+      <vbitrate>8000k</vbitrate>
+      <abitrate>128k</abitrate>
+      <device>mobile</device>
+      <enabled>1</enabled>
+   </profile>
+</profiles>


### PR DESCRIPTION
## Overview:
DLTS is moving away from Flash so only the mobile streaming files are required.  
Added two files:  
```
 conf/profiles-movie-scenes-mobile.xml
 conf/profiles-talking-heads-mobile.xml
```